### PR TITLE
Added ability to configure navigation orientation for SPPageController.

### DIFF
--- a/Example App/iOS Example/Controllers/ViewController.swift
+++ b/Example App/iOS Example/Controllers/ViewController.swift
@@ -53,7 +53,7 @@ class ViewController: UIViewController {
             controllers.append(navigationController)
         }
 
-        let pageController = SPPageController(childControllers: controllers, system: .page)
+        let pageController = SPPageController(childControllers: controllers, navigationOrientation: .horizontal, system: .page)
         
         // Example of manage layout margins.
         //pageController.view.layoutMargins = .init(horizontal: 50, vertical: 0)

--- a/Sources/SPPageController/Collection/SPPageCollectionController.swift
+++ b/Sources/SPPageController/Collection/SPPageCollectionController.swift
@@ -25,12 +25,12 @@ class SPPageCollectionController: UICollectionViewController, UICollectionViewDe
     
     // MARK: - Init
     
-    init(childControllers: [UIViewController]) {
+    init(childControllers: [UIViewController], scrollDirection: UICollectionView.ScrollDirection = .horizontal) {
         self.childControllers = childControllers
         let layout = SPPageCollectionViewFlowLayout()
         layout.minimumLineSpacing = .zero
         layout.minimumInteritemSpacing = .zero
-        layout.scrollDirection = .horizontal
+        layout.scrollDirection = scrollDirection
         super.init(collectionViewLayout: layout)
         
         for controller in childControllers {

--- a/Sources/SPPageController/Page/SPPageNativeController.swift
+++ b/Sources/SPPageController/Page/SPPageNativeController.swift
@@ -25,9 +25,9 @@ class SPPageNativeController: UIPageViewController, UIPageViewControllerDataSour
     
     // MARK: - Init
     
-    init(childControllers: [UIViewController]) {
+    init(childControllers: [UIViewController], navigationOrientation: UIPageViewController.NavigationOrientation = .horizontal) {
         self.childControllers = childControllers
-        super.init(transitionStyle: .scroll, navigationOrientation: .horizontal, options: [:])
+        super.init(transitionStyle: .scroll, navigationOrientation: navigationOrientation, options: [:])
         guard let firstController = self.childControllers.first else { return }
         setViewControllers([firstController], direction: SPPageNativeController.direction, animated: false, completion: nil)
     }

--- a/Sources/SPPageController/SPPageController.swift
+++ b/Sources/SPPageController/SPPageController.swift
@@ -46,13 +46,15 @@ open class SPPageController: UIViewController, SPPageControllerInterface {
     
     // MARK: - Init
     
-    public init(childControllers: [UIViewController], system: SPPageControllerSystem) {
+    public init(childControllers: [UIViewController], navigationOrientation: SPPageControllerNavigationOrientation = .horizontal, system: SPPageControllerSystem) {
         self.storedChildControllers = childControllers
         switch system {
         case .page:
-            containerController = SPPageNativeController(childControllers: storedChildControllers)
+            let orientation: UIPageViewController.NavigationOrientation = navigationOrientation == .horizontal ? .horizontal : .vertical
+            containerController = SPPageNativeController(childControllers: storedChildControllers, navigationOrientation: orientation)
         case .scroll:
-            containerController = SPPageCollectionController(childControllers: storedChildControllers)
+            let direction: UICollectionView.ScrollDirection = navigationOrientation == .horizontal ? .horizontal: .vertical
+            containerController = SPPageCollectionController(childControllers: storedChildControllers, scrollDirection: direction)
         }
         super.init(nibName: nil, bundle: nil)
     }

--- a/Sources/SPPageController/SPPageControllerSystem.swift
+++ b/Sources/SPPageController/SPPageControllerSystem.swift
@@ -26,3 +26,9 @@ public enum SPPageControllerSystem {
     case page
     case scroll
 }
+
+public enum SPPageControllerNavigationOrientation {
+    
+    case vertical
+    case horizontal
+}


### PR DESCRIPTION
## Goal
<!--- Provide details about reason changes. -->
Added ability to configure navigation orientation for SPPageController, I added a parameter name `navigationOrientation` of type `SPPageControllerNavigationOrientation`, please note that it is an optional parameter, the default value is `horizontal`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Testing in compability platforms
- [x] Installed correct via `Swift Package Manager` and `Cocoapods`
